### PR TITLE
bugfix: replace npm pack command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import { exec } from 'node:child_process'
-import { promises as fs } from 'node:fs'
+import { createWriteStream, promises as fs } from 'node:fs'
+import http from 'node:http'
+import https from 'node:https'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as tar from 'tar'
-
 /**
- * 使用 `npm pack` 获取一个 npm 包，解压它，读取 `package.json` 以获取 main 字段，
+ * 使用 `npm view` 获取一个 npm 包可下载链接，下载后解压读取 `package.json` 以获取 main 字段，
  * 读取主文件的内容，然后清理临时文件。
  *
  * @param options - 获取包的选项。
@@ -15,39 +16,54 @@ import * as tar from 'tar'
  * @returns 获取包的主文件的内容。
  * @throws 如果包无法获取、解压或读取，将抛出错误。
  */
-export async function fetchWithPack(options: { name: string, dist?: string, retry?: number }) {
-  let { name, dist, retry = 1 } = options
+export async function fetchAndExtractPackage(options: { name: string, dist?: string, retry?: number }) {
+  const { name, dist, retry = 1 } = options
+  const tempFile = name.split('/').join('-')
   const url = typeof __filename !== 'undefined' ? __filename : fileURLToPath(import.meta.url)
-  const tempDir = path.join(url, '..', 'temp')
-  const tarballPattern = `${name.replace('@', '').replace('/', '-')}-.*.tgz`
+  const tempDir = path.join(url, '..', tempFile)
   try {
     // Create temporary directory
     await fs.mkdir(tempDir, { recursive: true })
 
-    // Fetch the package tarball using npm pack
-    await new Promise((resolve, reject) => {
-      const fetch = () => {
-        exec(`npm pack ${name} --pack-destination ${tempDir}`, (error) => {
+    // Get the package tarball URL
+    const tarballUrl = await retryAsync(async () => {
+      return new Promise((resolve, reject) => {
+        exec(`npm view ${name} dist.tarball`, (error, stdout) => {
           if (error) {
-            if (retry > 0) {
-              fetch()
-              retry--
-            }
-            else {
-              reject(error)
-            }
+            reject(error)
           }
           else {
-            resolve(true)
+            resolve(stdout.trim())
           }
         })
-      }
-      fetch()
-    })
+      })
+    }, retry)
+    if (!tarballUrl)
+      return ''
+    const protocol = new URL(tarballUrl).protocol
+    const lib = protocol === 'https:' ? https : http
+    const tgzPath = path.join(tempDir, `${tempFile}.tgz`)
+    await retryAsync(async () => {
+      const tgzFile = createWriteStream(tgzPath)
 
-    const [tarballPath] = await fs.readdir(tempDir).then(files => files.filter(file => file.match(tarballPattern)))
+      return new Promise<void>((resolve, reject) => {
+        lib.get(tarballUrl, (response) => {
+          response.pipe(tgzFile)
+          tgzFile.on('finish', () => {
+            tgzFile.close()
+            resolve()
+          })
+        }).on('error', (error) => {
+          fs.unlink(`${name}.tgz`).catch((error) => {
+            reject(error)
+          })
+          reject(error)
+        })
+      })
+    }, retry)
+
     // Extract the tarball
-    await tar.x({ file: path.join(tempDir, tarballPath), cwd: tempDir })
+    await tar.x({ file: tgzPath, cwd: tempDir })
 
     // Read package.json to get the main field
     const packageJsonPath = path.join(tempDir, 'package', 'package.json')
@@ -80,5 +96,19 @@ export async function fetchWithPack(options: { name: string, dist?: string, retr
     // Clean up in case of error
     await fs.rm(tempDir, { recursive: true, force: true })
     throw error
+  }
+}
+
+async function retryAsync<T>(fn: () => Promise<T>, retries: number): Promise<T> {
+  try {
+    return await fn()
+  }
+  catch (error: any) {
+    if (retries > 0) {
+      return retryAsync(fn, retries - 1)
+    }
+    else {
+      throw error
+    }
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { fetchWithPack } from '../src'
+import { fetchAndExtractPackage } from '../src'
 
 describe('should', () => {
   it('exported', async () => {
-    const res = await fetchWithPack({
+    const res = await fetchAndExtractPackage({
       name: '@common-intellisense/vuetify3',
       retry: 5,
       dist: 'index.cjs',


### PR DESCRIPTION
Npm pack command requires a package.json file in the directory

Use the npm view command to obtain the download link for the npm package, and download it through the HTTP module
